### PR TITLE
adding GAMESHELL to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
+option(GAMESHELL "Set to ON if targeting an GameShell device" ${GAMESHELL})
 option(PANDORA "Set to ON if targeting an OpenPandora device" ${PANDORA})
 option(ODROID "Set to ON if targeting an ODroid device" ${ODROID})
 option(PYRA "Set to ON if targeting an DragonBox Pyra device" ${PANDORA})
@@ -8,7 +9,9 @@ option(USE_CCACHE "Set to ON to use ccache if present in the system" ${USE_CCACH
 
 option(USE_SDL2 "Use SDL2 instead of SDL1.2" ${USE_SDL2})
 
-
+if(GAMESHELL)
+	add_definitions(-DGAMESHELL)
+endif()
 if(PANDORA)
 	add_definitions(-DPANDORA)
 endif()

--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -59,16 +59,26 @@ void Input_KeyEvent(SDL_Event* evt)
         case SDLK_RCTRL:    bR = w; break;
         case SDLK_RSHIFT:   bL = w; break;
         case SDLK_LCTRL:    bSelect = w; break;
-		case SDLK_LALT:     bStart = w; break;
+	case SDLK_LALT:     bStart = w; break;
 #elif defined(CHIP)
-		case SDLK_MINUS:        bFaceUp = w; break;
-		case SDLK_o:            bFaceDown = w; break;
-		case SDLK_0:            bFaceLeft = w; break;
-		case SDLK_EQUALS:       bFaceRight = w; break;
-		case SDLK_1:            bR = w; break;
-		case SDLK_2:            bL = w; break;
-		case SDLK_SPACE:        bSelect = w; break;
-		case SDLK_RETURN:       bStart = w; break;
+	case SDLK_MINUS:        bFaceUp = w; break;
+	case SDLK_o:            bFaceDown = w; break;
+	case SDLK_0:            bFaceLeft = w; break;
+	case SDLK_EQUALS:       bFaceRight = w; break;
+	case SDLK_1:            bR = w; break;
+	case SDLK_2:            bL = w; break;
+	case SDLK_SPACE:        bSelect = w; break;
+	case SDLK_RETURN:       bStart = w; break;
+#elif defined(GAMESHELL)
+	case SDLK_i:        bFaceUp = w; break;
+        case SDLK_k:        bFaceDown = w; break; //jump
+        case SDLK_j:        bFaceLeft = w; break; //slash
+        case SDLK_u:        bFaceRight = w; break; //secondary weapon
+	case SDLK_SPACE:        bR = w; break; //switch weapon
+        // case SDLK_w:        bL = w; break; //switch weapon
+	// case SDLK_SPACE:    bSelect = w; break;
+	case SDLK_ESCAPE:   bSelect = w; break;
+        case SDLK_RETURN:   bStart = w; break;
 #else
         case SDLK_e:        bFaceUp = w; break;
         case SDLK_x:        bFaceDown = w; break;
@@ -76,8 +86,8 @@ void Input_KeyEvent(SDL_Event* evt)
         case SDLK_d:        bFaceRight = w; break;
         case SDLK_r:        bR = w; break;
         case SDLK_w:        bL = w; break;
-		case SDLK_SPACE:    bSelect = w; break;
-		case SDLK_ESCAPE:   bSelect = w; break;
+	case SDLK_SPACE:    bSelect = w; break;
+	case SDLK_ESCAPE:   bSelect = w; break;
         case SDLK_RETURN:   bStart = w; break;
 #endif
     }


### PR DESCRIPTION
[GameShell](https://www.clockworkpi.com/) is an open-source, open-hardware modular game console. It is based on clockworkpi a Quad-core Cortex-A7 CPU sbc. 

Modified `CMakeLists.txt` to include a `GAMESHELL` variable. Also changed `input.c` to include a mapping for GameShell's keypad.

Only changed `SDL` and not `SDL2` because GameShell has only software renderer (not OpenGL) untill now.

How to compile:

Similar to the original instructions:

```
cmake . -DGAMESHELL=ON
make
```