### PR TITLE
Swap FaceLeft/FaceRight buttons.

### DIFF
--- a/src/sdl2/input.c
+++ b/src/sdl2/input.c
@@ -160,8 +160,8 @@ void Input_ControlButtonEvent(SDL_Event* evt) {
 	switch(evt->cbutton.button)
 	{
 		case SDL_CONTROLLER_BUTTON_A:	jFaceDown = w; break;
-		case SDL_CONTROLLER_BUTTON_B: 	jFaceLeft = w; break;
-		case SDL_CONTROLLER_BUTTON_X: 	jFaceRight = w; break;
+		case SDL_CONTROLLER_BUTTON_B: 	jFaceRight = w; break;
+		case SDL_CONTROLLER_BUTTON_X: 	jFaceLeft = w; break;
 		case SDL_CONTROLLER_BUTTON_Y: 	jFaceUp = w; break;
 		case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: jL = w; break;
 		case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: jR = w; break;


### PR DESCRIPTION
If these are meant to mimic the Xbox 360 layout, then shouldn't they be like this?

Currently, the sword attack is on the "east" face button. Is this correct? It feels more natural to me for it to be on the "west" button instead.

I believe a similar swap should be applied in `../sdl/input.c` but I am currently unable to test this.