### PR TITLE
Accept any available SDL2 Renderer.

### DIFF
--- a/src/sdl2/graphics.c
+++ b/src/sdl2/graphics.c
@@ -81,7 +81,7 @@ void PHL_GraphicsInit()
 		printf("Error creating SDL Window (%s)\n", SDL_GetError());
 		exit(-1);
 	}
-	renderer = SDL_CreateRenderer(window, 0, SDL_RENDERER_TARGETTEXTURE | SDL_RENDERER_ACCELERATED);
+	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_TARGETTEXTURE | SDL_RENDERER_ACCELERATED);
 	if(!renderer)
 	{
 		printf("Error creating SDL Renderer (%s)\n", SDL_GetError());


### PR DESCRIPTION
This fixes a failure to initialize on certain SDL2 builds on systems where OpenGL ES is the only native API available, but the Desktop OpenGL renderer is exposed (e.g. for GL4ES).