### PR TITLE
Update AppStream metadata to 1.0 standards

### DIFF
--- a/io.github.ptitSeb.hydracastlelabyrinth.appdata.xml
+++ b/io.github.ptitSeb.hydracastlelabyrinth.appdata.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
-  <id type="desktop">io.github.ptitSeb.hydracastlelabyrinth</id>
+<component type="desktop-application">
+  <id>io.github.ptitSeb.hydracastlelabyrinth</id>
   <name>Hydra Castle Labyrinth</name>
-  <developer_name>E.Hashimoto, Anonymous, HCL Contributors</developer_name>
-  <summary>A modern Linux port of the "metroidvania" game Hydra Castle Labyrinth.</summary>
+  <developer id="ptitseb.github.io/hydracastlelabyrinth/"><name>E.Hashimoto, Anonymous, HCL Contributors</name></developer>
+  <summary>A modern Linux port of the "metroidvania" game Hydra Castle Labyrinth</summary>
+  <launchable type="desktop-id">io.github.ptitSeb.hydracastlelabyrinth.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license> GPL-2.0-only</project_license>
   <url type="homepage">https://github.com/ptitSeb/hydracastlelabyrinth/</url>
@@ -28,4 +29,5 @@
     <content_attribute id="violence-fantasy">moderate</content_attribute>
   </content_rating>
   <update_contact>https://github.com/ptitSeb/hydracastlelabyrinth/issues</update_contact>
-</application>
+</component>
+


### PR DESCRIPTION
Flathub have [updated their build infrastructure](https://docs.flathub.org/blog/improved-build-validation/) to validate metadata against the AppStream 1.0 standard instead of older versions. I've run their linter against this file and fixed any issues reported.