### PR TITLE
Update metadata

### DIFF
--- a/io.github.ptitSeb.hydracastlelabyrinth.metainfo.xml
+++ b/io.github.ptitSeb.hydracastlelabyrinth.metainfo.xml
@@ -23,6 +23,9 @@
     <category>Game</category>
   </categories>
   <releases>
+    <release version="1.1" date="2024-02-27">
+    <description>This release fixes saving game state and configuration in the Flatpak build, and detection of game controller names.</description>
+    </release>
     <release version="1" date="2024-02-07"/>
   </releases>
   <content_rating type="oars-1.1">


### PR DESCRIPTION
Added new release info for an updated Flatpak build with a patch for saving game data and the controller name fix, and renamed the AppStream metadata file in line with recommendations from AppStream 1.0.